### PR TITLE
fix gson 丢失精度，gson 将数字类型都转换为double

### DIFF
--- a/sdk/src/main/java/com/qiniu/pandora/http/Response.java
+++ b/sdk/src/main/java/com/qiniu/pandora/http/Response.java
@@ -9,6 +9,7 @@ import okhttp3.MediaType;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Locale;
+import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * 定义HTTP请求的日志信息和常规方法
@@ -53,6 +54,8 @@ public final class Response {
 
     private byte[] body;
     private okhttp3.Response response;
+
+    private static ObjectMapper mapper = new ObjectMapper();
 
     private Response(okhttp3.Response response, int statusCode, String reqId, String xlog, String xvia,
                      String address, double duration, String error, byte[] body) {
@@ -175,6 +178,12 @@ public final class Response {
             return null;
         }
         String b = bodyString();
+
+        try {
+           return mapper.readValue(b, classOfT);
+        } catch (IOException e) {
+        }
+
         return Json.decode(b, classOfT);
     }
 


### PR DESCRIPTION
## Fixes [PDR-XXX](pdr-link-address)

## Changes
   
  - [ ] gson 会将数字都转换为double，导致类型发生变化没。如果ObjectMapper 失败则使用原来的逻辑。
  - [ ] feature2 
  - [ ] fixbug1
  - [ ] fixbug2
 
## Reviewers

  - [ ] @[someone] please review
  - [ ] @[someotherone] please review
    
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] CHANGELOG.md updated
   - [ ] Jira issue/task done